### PR TITLE
Add airDrop feature to allow distributing brand token to all users

### DIFF
--- a/backend_takehome_doc_responses.md
+++ b/backend_takehome_doc_responses.md
@@ -1,0 +1,16 @@
+# Your Tasks:
+1. Fix the tests
+	   - I think the test wasn't broken, there was an always false comparison to `campaignTypeTracker` which I removed
+
+   
+2. Write a feature that gives out tokens to users.
+   - Call this API (`localhost:1938/api/airDrop/create`) with this body
+```
+	{
+		"brandID": "1",
+		"numberOfTokens": 10000,
+		"effectiveDate": 1859660585112
+	}
+```
+3. Write tests
+   - Added to the test infrastructure

--- a/superman/cypress/integration/backend/crud/Get-Create-List-Airdrop.spec.js
+++ b/superman/cypress/integration/backend/crud/Get-Create-List-Airdrop.spec.js
@@ -1,0 +1,101 @@
+describe("Create and Get Air Drop", () => {
+    before(() => {
+        cy.post('test/clear-db');
+
+        cy.post('admin/seed_data/test').then(res => {
+            expect(res.status).to.eq(200);
+        });
+    });
+
+    it("get airDrop model - should fail", () => {
+        cy.post('api/airDrop/get', {
+            fakeProperty: "some value"
+        }).then(res => {
+            expect(res.status).to.eq(500, "wrong status code");
+            expect(res.body.error).not.to.eq(undefined);
+        });
+    });
+
+    it("create airDrop model", ()=>  {
+        cy.post('api/airDrop/create', {
+            id: "WTF",
+            brandID: "1",
+            numberOfTokens: 10000,
+            effectiveDate: Number.MAX_VALUE
+        }).then(res => {
+            expect(res.status).to.eq(200, "wrong status code");
+            expect(res.body.id).not.to.eq(undefined);
+            expect(res.body.id.length).not.to.eq(0);
+        });
+    });
+
+    it("get airDrop model - should succeed",  ()=>  {
+        cy.post('api/airDrop/get', { "id": "WTF" }).then(res => {
+            expect(res.status).to.eq(200, "wrong status code");
+            expect(res.body.brandID).to.eq("1");
+            expect(res.body.id).not.to.eq(undefined);
+            expect(res.body.id.length).not.to.eq(0);
+            expect(res.body.createdAtFormatted).not.to.eq("");
+            expect(res.body.createdAtFormatted).not.to.eq(undefined);
+        });
+    });
+
+    it('list models - expect one', () =>  {
+        cy.post('api/airDrop/list', {}).then(res => {
+            expect(res.status).to.eq(200, "wrong status code");
+            expect(res.body.length).to.eq(1);
+        });
+    });
+
+    it("create airDrop model", () =>  {
+        cy.post('api/airDrop/create', {
+            id: "WTF2",
+            brandID: "1",
+            numberOfTokens: 20000,
+            effectiveDate: Number.MAX_VALUE
+        }).then(res => {
+            expect(res.status).to.eq(200, "wrong status code");
+            expect(res.body.id).not.to.eq(undefined);
+            expect(res.body.id.length).not.to.eq(0);
+        });
+    });
+
+    it('list models - use search params',() =>  {
+        cy.post('api/airDrop/list', {
+            id: "WTF2",
+        }).then(res => {
+            expect(res.status).to.eq(200, "wrong status code");
+            expect(res.body.length).to.eq(1);
+        });
+    });
+
+    it('upsert models - should reject',() =>  {
+        cy.post('api/airDrop/upsert', {
+            id: "WTF2",
+        }).then(res => {
+            expect(res.status).to.eq(500, "wrong status code");
+        });
+    });
+
+    it('update models - should reject',() => {
+        cy.post('api/airDrop/update', {
+            id: "WTF2",
+        }).then(res => {
+            expect(res.status).to.eq(500, "wrong status code");
+        });
+    });
+
+    it('create models - no users, should reject',() => {
+        cy.post('test/clear-db');
+
+        cy.post('api/airDrop/create', {
+            id: "WTF",
+            brandID: "1",
+            numberOfTokens: 10000,
+            effectiveDate: Number.MAX_VALUE
+        }).then(res => {
+            expect(res.status).to.eq(500, "wrong status code");
+        });
+
+    });
+});

--- a/superman/src/business/airDropCalculations.js
+++ b/superman/src/business/airDropCalculations.js
@@ -1,0 +1,13 @@
+export const getTokenPerUser = (users, amount) => {
+    return amount / users;
+}
+
+const MONTH = ["January","February","March","April","May","June","July","August","September","October","November","December"];
+export const getTokenAwardDate =() => {
+    const d = new Date();
+    let mm = MONTH[d.getMonth()];
+    var dd = String(d.getDate()).padStart(2, '0');
+    var yyyy = d.getFullYear();
+
+    return `${mm} ${dd} ${yyyy}`;
+}

--- a/superman/src/models/airDrop.js
+++ b/superman/src/models/airDrop.js
@@ -1,0 +1,88 @@
+import {
+    addModelToInternalDB,
+    getModelFromInternalDB,
+    listModelsFromInternalDB,
+    modelExistsInInternalDB,
+    upsertModelInInternalDB,
+} from "../db/internalDB.js";
+import { validatePropertiesOnObject } from "../utils/validations.js";
+import _ from "lodash";
+import { getTokenAwardDate, getTokenPerUser } from '../business/airDropCalculations.js';
+
+const REQUIRED_FIELD_FOR_AIRDROP = ['brandID', 'numberOfTokens', 'effectiveDate'];
+const AIR_DROP = 'airDrop';
+const NON_CREATE_ERROR = "Only create is allowed, cannot upsert or update an already distributed air drop."
+
+export const hooks = {
+
+    upsert: () => {
+        throw NON_CREATE_ERROR;
+    },
+
+    update: () => {
+        throw NON_CREATE_ERROR;
+    },
+
+    createPost: (airDropModel, __) => {
+        const inputValid = validatePropertiesOnObject(airDropModel, REQUIRED_FIELD_FOR_AIRDROP);
+
+        if (!inputValid) {
+            throw `airDropModel requires the following fields ${REQUIRED_FIELD_FOR_AIRDROP.toString()} the input was this: ${JSON.stringify(
+                airDropModel
+            )}`;
+        }
+
+        // Find brand genereous enough to provide air drop, can assume they exist
+        const brand = getModelFromInternalDB('brand', { id: airDropModel.brandID });
+
+        // Time eligible means the user had an account at time of drop
+        const allTimeEligibleUsers = listModelsFromInternalDB('userAccount', (user) => {
+            {
+                return user.createdAt <= airDropModel.effectiveDate
+            }
+        });
+
+        // All eligible is both time eligible + never received drop before
+        // In actuality, never received drop before isn't a case that we should worry about
+        const allEligibleUsers = allTimeEligibleUsers.filter(user => {
+            return !modelExistsInInternalDB('dropActivity', {
+                userID: user.id,
+                source: AIR_DROP,
+                dropID: airDropModel.id,
+            });
+        });
+
+        const usersNum = allEligibleUsers.length;
+        if (usersNum === 0) {
+            throw 'There were exactly 0 users eligible for this drop';
+        }
+
+        const userDropAmount = getTokenPerUser(usersNum, airDropModel.numberOfTokens);
+
+        allEligibleUsers.forEach((user) => {
+            const tokenObj = (user.tokens ?? []).find(tok => tok.brandID === brand.id) ?? {
+                brandID: brand.id,
+                balance: 0,
+                USDBalance: 0,
+                lastUpdated: getTokenAwardDate(),
+            };
+            tokenObj.balance += userDropAmount;
+
+            upsertModelInInternalDB('userAccount', {
+                tokens: [tokenObj, ...(user.tokens ?? []).filter(tok => tok.brandID !== brand.id)]
+            }, { id: user.id });
+
+            addModelToInternalDB(`dropActivity`, {
+                userID: user.id,
+                source: AIR_DROP,
+                dropID: airDropModel.id,
+            });
+        })
+
+        return {
+            ...airDropModel,
+            eligibleUsers: usersNum,
+            tokenPerUser: userDropAmount
+        };
+    },
+};

--- a/superman/src/models/airDrop.test.js
+++ b/superman/src/models/airDrop.test.js
@@ -1,0 +1,77 @@
+import { addModelToInternalDB, getModelFromInternalDB } from "../db/internalDB.js";
+import { runHooks } from "../routes/hooks/crudHooks.js";
+import _ from "lodash";
+
+describe("air drop -- hooks", () => {
+    it("getPost hook should return the distribute the tokens to all users", async () => {
+        const BRAND_ID = `brandID1`;
+        const ELIGIBLE_USERS = 4;
+        const TOTAL = 10000;
+        const TOKEN_PER = TOTAL / ELIGIBLE_USERS;
+        const INITIAL_BALANCE = 1;
+
+        // add the brand first so that we set also test that the brandID on the campaign
+        addModelToInternalDB(`brand`, { id: BRAND_ID, userID: "U1" });
+
+        // Users
+        addModelToInternalDB(`userAccount`, { id: "U1" });
+        addModelToInternalDB(`userAccount`, { id: "U2" });
+
+        // User, eligible for drop, with tokens already
+        addModelToInternalDB(`userAccount`, {
+            id: "U3", tokens: [
+                {
+                    "brandID": BRAND_ID,
+                    "balance": INITIAL_BALANCE,
+                }
+            ]
+        });
+        // User, eligible for drop, with other tokens
+        const lastInsert = addModelToInternalDB(`userAccount`, {
+            id: "U4", tokens: [
+                {
+                    "brandID": `not-${BRAND_ID}`,
+                    "balance": 1,
+                    "lastUpdated": "August 05 2022"
+                }
+            ]
+        });
+
+        const createAirDropRequest = {
+            "brandID": BRAND_ID,
+            "numberOfTokens": 10000,
+            "effectiveDate": lastInsert.createdAt,
+        };
+
+        // The actual drop
+        addModelToInternalDB(`airDrop`, createAirDropRequest);
+
+        // hook to distribute 
+        const airDropFromDB = await runHooks(`createPost`, `airDrop`, createAirDropRequest, {});
+
+        // User, created after drop effective time
+        addModelToInternalDB(`userAccount`, { id: "U5" });
+
+        expect(airDropFromDB.brandID).toBe(BRAND_ID);
+        expect(airDropFromDB.eligibleUsers).toBe(ELIGIBLE_USERS);
+        expect(airDropFromDB.tokenPerUser).toBe(TOKEN_PER);
+
+        // Tokens dropped correctly
+        const eligible1 = getModelFromInternalDB('userAccount', { id: "U1" });
+        expect(eligible1.tokens[0].balance).toBe(TOKEN_PER);
+
+        const eligible2 = getModelFromInternalDB('userAccount', { id: "U2" });
+        expect(eligible2.tokens[0].balance).toBe(TOKEN_PER);
+
+        const eligible3 = getModelFromInternalDB('userAccount', { id: "U3" });
+        expect(eligible3.tokens[0].balance).toBe(TOKEN_PER + INITIAL_BALANCE);
+
+        const eligible4 = getModelFromInternalDB('userAccount', { id: "U4" });
+        expect(eligible4.tokens.length > 1).toBe(true);
+        expect(eligible4.tokens.some((tok) => tok.brandID === BRAND_ID && tok.balance === TOKEN_PER)).toBe(true);
+
+        const ineligible5 = getModelFromInternalDB('userAccount', { id: "U5" });
+        expect(ineligible5.tokens).toBeFalsy();
+
+    });
+});

--- a/superman/src/models/campaign.js
+++ b/superman/src/models/campaign.js
@@ -10,16 +10,13 @@ export const SUPPORTED_SOCIAL_MEDIA_PLATFORMS = ["facebook", "twitter", "instagr
 export const CAMPAIGN_TYPE_ENCOURAGE_REFERRALS = `encourageReferrals`;
 export const CAMPAIGN_TYPE_ENCOURAGE_PURCHASES = `encouragePurchases`;
 
-const campaignTypeTracker = "PURCHASES;";
-
 export var hooks = {
 	list: function (model, extra) {
 		// filter by the logged-in user
 		model.userID = extra.userID;
 		return model;
 	},
-	getPost: function (campaign, extra) {
-        var defaultCampaign = {};
+	getPost: function (campaign, __) {
 
 		if (campaign.campaignType === CAMPAIGN_TYPE_ENCOURAGE_PURCHASES) {
 			removeReferralCampaignFields(campaign);
@@ -91,16 +88,12 @@ export var hooks = {
 				...stats,
 			};
 
-            if (campaignTypeTracker != "PURCHASES") {
-                basicCampaign = defaultCampaign;
-            }
-
 			return basicCampaign;
 		}
 
 		return campaign;
 	},
-	create: function (campaign, extra) {
+	create: function (campaign, __) {
 		// add the brandID to the campaign automatically
 		const brandUserID = campaign.userID;
 		const brand = getModelFromInternalDB(`brand`, {
@@ -110,7 +103,7 @@ export var hooks = {
 		campaign.brandID = brand.id;
 		return campaign;
 	},
-	createPost: function (campaign, extra) {
+	createPost: function (campaign, __) {
 		// TODO: call createRecurringBill here, totalMonthy for encourage purchases
 		if (campaign.campaignType === CAMPAIGN_TYPE_ENCOURAGE_REFERRALS) {
 			let stats = {

--- a/superman/src/models/campaign.test.js
+++ b/superman/src/models/campaign.test.js
@@ -1,9 +1,7 @@
-import { addModelToInternalDB, listModelsFromInternalDB, getModelFromInternalDB } from "../db/internalDB.js";
+import { addModelToInternalDB } from "../db/internalDB.js";
 import { runHooks } from "../routes/hooks/crudHooks.js";
-import { CAMPAIGN_TYPE_ENCOURAGE_PURCHASES, CAMPAIGN_TYPE_ENCOURAGE_REFERRALS } from "../models/campaign.js";
-import { convertBrandTokenAmountToUSD } from "../business/campaignCalculations.js";
+import { CAMPAIGN_TYPE_ENCOURAGE_REFERRALS } from "./campaign.js";
 import _ from "lodash";
-import { logger } from "../logger.js";
 import { ulid } from "ulid";
 
 describe("encourage referrals campaign -- hooks", function () {
@@ -61,8 +59,9 @@ describe("encourage referrals campaign -- hooks", function () {
 		// test that the brand ID is set by the hook
 		expect(referralCampaignFromDB.brandID).toBe(BRAND_ID);
 
-		// addModelToInternalDB(`campaign`, referralCampaignFromDB);
 		expect(referralCampaignFromDB.remainingBudget).toBe(undefined);
+
+		addModelToInternalDB(`campaign`, referralCampaignFromDB);
 
 		const campaignReturned = await runHooks("getPost", `campaign`, referralCampaignFromDB, {});
 
@@ -70,6 +69,8 @@ describe("encourage referrals campaign -- hooks", function () {
 		expect(campaignReturned.totalFundAmount).toBe(referralCampaignFromDB.totalFundAmount);
 
 		// confirm there's a remaining budget field and that it's correct
+		// In the test data, only FB likes are active so...
+		// 1260 - 3.5*100 = 910
 		expect(campaignReturned.remainingBudget).toBe(910);
 	});
 });

--- a/superman/src/routes/api.js
+++ b/superman/src/routes/api.js
@@ -10,7 +10,7 @@ import _ from "lodash";
 
 import { logger } from "../../src/logger.js";
 import { runHooks } from "./hooks/crudHooks.js";
-import { getUserIDFromRequest, getWidgetBrandIDFromRequest, notWidgetUserBrandID } from "../jwt.js";
+import { getWidgetBrandIDFromRequest, notWidgetUserBrandID } from "../jwt.js";
 
 // todo-graham: generalize the error-catching code (and logging)
 

--- a/superman/src/routes/hooks/masterHookList.js
+++ b/superman/src/routes/hooks/masterHookList.js
@@ -1,6 +1,7 @@
 import { hooks as campaignHooks } from "../../models/campaign.js";
+import { hooks as airDropHooks } from "../../models/airDrop.js";
 
 export var allHooks = {
-	campaign: campaignHooks,
-    // todo-graham: need to fill in
+    campaign: campaignHooks,
+    airDrop: airDropHooks,
 };

--- a/superman/src/utils/validations.js
+++ b/superman/src/utils/validations.js
@@ -1,0 +1,13 @@
+
+export const validatePropertiesOnObject = (obj, properties) => {
+
+    if (typeof obj !== "object") {
+        return false;
+    }
+
+    const valid = properties.every(element =>
+        obj.hasOwnProperty(element)
+    );
+
+    return valid;
+}


### PR DESCRIPTION
# Tasks and Responses

1. Fix the tests
	   - I think the test wasn't broken, there was an always false comparison to `campaignTypeTracker` which I removed

   
2. Write a feature that gives out tokens to users.
   - Call this API (`localhost:1938/api/airDrop/create`) with this body
```
	{
		"brandID": "1",
		"numberOfTokens": 10000,
		"effectiveDate": 1859660585112
	}
```
3. Write tests
   - Added to the test infrastructure
