### PR TITLE
Add giveaway feature

### DIFF
--- a/response.md
+++ b/response.md
@@ -1,0 +1,23 @@
+# Todo:
+
+1. Tests
+	-  `campaignTypeTracker` was initialized and only used in an always true comparison that was setting the model returned to be an empty object `defaultCampaign`. Both variable initialization and comparison were removed in order to fix tests.
+
+2. Tests
+   - Added e2es tests
+   - Added unit tests
+
+3. Implement giveaway endpoint to distribute brand tokens to all users in the db.
+   -  endpoint url: `localhost:1938/api/giveaway/create`
+   - method: POST
+   - body:
+```
+	{
+		"brandID": "1",
+		"tokensAmount": 10000
+	}
+```
+
+4. Add a history record for each giveaway action
+  - timestamp
+  - data

--- a/superman/cypress/integration/backend/crud/Giveaway.spec.js
+++ b/superman/cypress/integration/backend/crud/Giveaway.spec.js
@@ -1,0 +1,115 @@
+import { brand, userAccount } from '../../../../seed_data/test';
+
+function pickRandom(arr) {
+    const random = Math.floor(Math.random() * (arr.length - 1) + 0);
+    return arr[random];
+}
+
+function getTokenByBrandId(user, brandID) {
+    return (user.tokens ?? []).find(token => token.brandID === brandID) ?? {
+        brandID: brandID,
+        balance: 0,
+        USDBalance: 0,
+        lastUpdated: null,
+    };
+}
+
+describe("Giveaway", () => {
+    const brandModel = pickRandom(brand);
+    const brandID = brandModel.id;
+    
+    before(() => {
+        cy.post('test/clear-db');
+
+        cy.post('admin/seed_data/test').then(res => {
+            expect(res.status).to.eq(200);
+        });
+    });
+
+    // CREATE
+
+    it("create: Giveaway model - reject with 0 or negative number of tokens", () => {
+        const wrongAmounts = [-1, 0, -100, -10.5];
+
+        cy.post('api/giveaway/create', {
+            brandID,
+            tokensAmount: pickRandom(wrongAmounts)
+        }).then(res => {
+            expect(res.status).to.eq(500, "wrong status code");
+            expect(res.body.error).to.match(/Invalid number of tokens. Value must be greater than 0;/);
+        });
+    });
+
+    it("create: Giveaway model ", () => {
+        
+        const validTokenAmounts = [1, 77, 1000000];
+        let users = userAccount;
+        const tokensAmount = pickRandom(validTokenAmounts);
+        let tokensPerUser = tokensAmount / userAccount.length;
+
+        cy.post('api/giveaway/create', {
+            brandID,
+            tokensAmount,
+        }).then(res => {
+            expect(res.status).to.eq(200, "wrong status code");
+            expect(res.body.id).not.to.eq(undefined);
+            expect(res.body.id.length).not.to.eq(0);
+            expect(res.body.awardedUsers).to.eq(users.length);
+        });
+
+        users.forEach(user => {
+            cy.post('api/userAccount/get', {
+                id: user.id
+            }).then(res => {
+                const tokenBeforeGiveaway = getTokenByBrandId(user, brandID);
+                const tokenAfterGiveaway = getTokenByBrandId(res.body, brandID);
+                expect(res.status).to.eq(200, "wrong status code");
+                expect(tokenAfterGiveaway.balance).to.eq(tokenBeforeGiveaway.balance + tokensPerUser, `User ${user.id} wrong amount of tokens`);
+            });
+        })
+    });
+
+    // GET
+
+    it("get: Giveaway model - should succeed", () => {
+
+        cy.post('api/giveaway/get', {
+            brandID,
+        }).then(res => {
+            expect(res.status).to.eq(200, "failed getting giveaway");
+        });
+    });
+
+    // LIST
+
+    it('list: giveaway model - expect one', () => {
+        cy.post('api/giveaway/list', {}).then(res => {
+            expect(res.status).to.eq(200, "wrong status code");
+            expect(res.body.length).not.to.eq(0);
+        });
+    });
+
+    it('list: models - use search params', () => {
+        cy.post('api/giveaway/list', {
+            brandID
+        }).then(res => {
+            expect(res.status).to.eq(200, "wrong status code");
+            expect(res.body.length).not.to.eq(0);
+        });
+    });
+
+    // NOT ALLOWED METHODS: UPDATE/UPSERT
+    let notAllowedMethods = ["update" , "upsert"];
+
+    notAllowedMethods.forEach(method => {
+        it(`${method}: giveaway model - should fail`, () => {
+            cy.post(`api/giveaway/${method}`, {
+                brandID
+            }).then(res => {
+                expect(res.status).to.eq(500, "wrong status code");
+                expect(res.body.error).not.to.eq(undefined);
+            });
+        })
+    })
+
+});

--- a/superman/package.json
+++ b/superman/package.json
@@ -12,7 +12,8 @@
         "units": "./scripts/kill_nodemon.sh 'jest' && node_modules/.bin/nodemon -x 'jest --config ./jest.config.js' --ignore './src/testdata/**' --ignore './db/**' --ignore pipes_output.log",
         "once_e2es": "npm run once_e2es_backend; npm run once_e2es_fullstack",
         "once_units": "jest --config ./jest.config.js",
-        "serve": "./scripts/kill_nodemon.sh app.js; export SEED_WITH_TEST_DATA=true && rm -f ./db/* && node_modules/.bin/nodemon --ignore './src/testdata/**' --ignore './db/**' --ignore pipes_output.log app.js"
+        "serve": "./scripts/kill_nodemon.sh app.js; export SEED_WITH_TEST_DATA=true && rm -f ./db/* && node_modules/.bin/nodemon --ignore './src/testdata/**' --ignore './db/**' --ignore pipes_output.log app.js",
+        "debug": "./scripts/kill_nodemon.sh app.js; export SEED_WITH_TEST_DATA=true && rm -f ./db/* && node_modules/.bin/nodemon --inspect --ignore './src/testdata/**' --ignore './db/**' --ignore pipes_output.log app.js"
     },
     "repository": {
         "type": "git",

--- a/superman/src/business/giveTokensForGiveawayCalculations.js
+++ b/superman/src/business/giveTokensForGiveawayCalculations.js
@@ -1,0 +1,3 @@
+export const getTokenPerUser = (usersCount, tokenAmount) => {
+    return tokenAmount / usersCount;
+}

--- a/superman/src/models/campaign.js
+++ b/superman/src/models/campaign.js
@@ -10,8 +10,6 @@ export const SUPPORTED_SOCIAL_MEDIA_PLATFORMS = ["facebook", "twitter", "instagr
 export const CAMPAIGN_TYPE_ENCOURAGE_REFERRALS = `encourageReferrals`;
 export const CAMPAIGN_TYPE_ENCOURAGE_PURCHASES = `encouragePurchases`;
 
-const campaignTypeTracker = "PURCHASES;";
-
 export var hooks = {
 	list: function (model, extra) {
 		// filter by the logged-in user
@@ -90,10 +88,6 @@ export var hooks = {
 				...campaign,
 				...stats,
 			};
-
-            if (campaignTypeTracker != "PURCHASES") {
-                basicCampaign = defaultCampaign;
-            }
 
 			return basicCampaign;
 		}

--- a/superman/src/models/giveTokensForGiveawayAction.js
+++ b/superman/src/models/giveTokensForGiveawayAction.js
@@ -1,0 +1,88 @@
+import {
+	getModelFromInternalDB,
+	upsertModelInInternalDB,
+	listModelsFromInternalDB,
+	addModelToInternalDB
+} from "../db/internalDB.js";
+import _ from "lodash";
+import { getTokenPerUser } from '../business/giveTokensForGiveawayCalculations.js';
+
+const REQUIRED_PROPERTIES = ['brandID', 'tokensAmount'],
+ METHOD_NOT_ALLOWED_ERROR = 'Cannot upsert or update a giveaway';
+
+export const hooks = {
+	
+	upsert: () => {
+		throw METHOD_NOT_ALLOWED_ERROR;
+	},
+
+	update: () => {
+		throw METHOD_NOT_ALLOWED_ERROR;
+	},
+
+	create: (giveawayAction) => {
+		// Validations
+		if (typeof giveawayAction !== "object") {
+			throw `giveawayAction does not accept anything other than a single object as input, you passed in a ${typeof giveawayAction} type that looks like this: ${JSON.stringify(
+				giveawayAction
+			)}`;
+		}
+
+		REQUIRED_PROPERTIES.forEach(property => {
+			if (!(property in giveawayAction)) {
+				throw `giveawayAction requires the following fields: (${REQUIRED_PROPERTIES.toString()}) the input was this: ${JSON.stringify(
+					giveawayAction
+				)}`;
+			}
+		})
+
+		if (giveawayAction.tokensAmount <= 0) {
+			throw `Invalid number of tokens. Value must be greater than 0;`
+		}
+		return giveawayAction;
+	},
+
+	createPost: (giveawayAction, extra) => {
+
+		// Find brand assuming it exists
+		const brand = getModelFromInternalDB('brand', { id: giveawayAction.brandID });
+
+		// Fetch users
+		const users = listModelsFromInternalDB('userAccount', {});
+
+		const tokensPerUser = users.length ? getTokenPerUser(users.length, giveawayAction.tokensAmount) : 0;
+		
+		if (users.length) {
+			
+			users.forEach((user) => {
+				const userWallet = (user.tokens ?? []).find(token => token.brandID === brand.id) ?? {
+					brandID: brand.id,
+					balance: 0,
+					USDBalance: 0,
+					lastUpdated: null,
+				};
+				userWallet.balance += tokensPerUser;
+				// use timestamp instead of MMM DD YYYY or formatted Coordenated Universal Time
+				userWallet.lastUpdated = giveawayAction.createdAt;
+
+				upsertModelInInternalDB('userAccount', {
+					tokens: [userWallet, ...(user.tokens ?? []).filter(tok => tok.brandID !== brand.id)]
+				}, { id: user.id });
+			})
+		}
+
+		addModelToInternalDB(`givawayHistory`, {
+			source: '/api/giveaway/create',
+			createdAt: giveawayAction.createdAt,
+			data: {
+				...giveawayAction
+			}
+		});
+
+		return {
+			...giveawayAction,
+			tokensPerUser: tokensPerUser,
+			awardedUsers: users.length
+		};
+	},
+};

--- a/superman/src/models/giveTokensForGiveawayAction.test.js
+++ b/superman/src/models/giveTokensForGiveawayAction.test.js
@@ -1,0 +1,39 @@
+import { addModelToInternalDB, getModelFromInternalDB } from "../db/internalDB.js";
+import { runHooks } from "../routes/hooks/crudHooks.js";
+import _ from "lodash";
+
+describe("giveaway -- hooks", () => {
+	it("createPost hook should return the distribute the tokens to all users", async () => {
+		const BRAND_ID = '1';
+		const TOKENS_AMOUNT = 10000;
+		const USERS_AMOUNT = 10;
+		const TOKENS_PER_USER = TOKENS_AMOUNT / USERS_AMOUNT;
+
+		// add the brand first
+		addModelToInternalDB(`brand`, { id: BRAND_ID, userID: "U1" });
+
+		// Users
+		for (let i = 0; i < USERS_AMOUNT; i++) {
+			addModelToInternalDB(`userAccount`, { id: `user_${i}` });
+		}
+
+		const giveawayRequest = {
+			"brandID": BRAND_ID,
+			"tokensAmount": TOKENS_AMOUNT
+		};
+
+		// hook to distribute 
+		const giveawayFromDB = await runHooks(`createPost`, `giveaway`, giveawayRequest, {});
+
+		expect(giveawayFromDB.brandID).toBe(BRAND_ID);
+		expect(giveawayFromDB.tokensAmount).toBe(TOKENS_AMOUNT);
+		expect(giveawayFromDB.awardedUsers).toBe(USERS_AMOUNT);
+		expect(giveawayFromDB.tokensPerUser).toBe(TOKENS_PER_USER);
+
+		// Verify history record
+		const giveawayHistoryFromDB = getModelFromInternalDB("givawayHistory", { data: giveawayRequest });
+		expect(JSON.stringify(giveawayHistoryFromDB.data)).toBe(JSON.stringify(giveawayRequest));
+		expect(giveawayHistoryFromDB.source).toBe('/api/giveaway/create');
+
+	});
+});

--- a/superman/src/routes/hooks/masterHookList.js
+++ b/superman/src/routes/hooks/masterHookList.js
@@ -1,6 +1,9 @@
 import { hooks as campaignHooks } from "../../models/campaign.js";
+import { hooks as giveawayHooks } from "../../models/giveTokensForGiveawayAction.js";
 
 export var allHooks = {
 	campaign: campaignHooks,
+    giveaway: giveawayHooks,
+
     // todo-graham: need to fill in
 };


### PR DESCRIPTION
1. Tests
	-  `campaignTypeTracker` was initialized and only used in an always true comparison that was setting the model returned to be an empty object `defaultCampaign`. Both variable initialization and comparison were removed in order to fix tests.

2. Tests
   - Added e2es tests
   - Added unit tests

3. Implement giveaway endpoint to distribute brand tokens to all users in the db.
   -  endpoint url: `localhost:1938/api/giveaway/create`
   - method: POST
   - body:
```
	{
		"brandID": "1",
		"tokensAmount": 10000
	}
```

4. Add a history record for each giveaway action
  - timestamp
  - reques data